### PR TITLE
fix missing clips

### DIFF
--- a/front/src/components/Pages/ClipPage/styles.ts
+++ b/front/src/components/Pages/ClipPage/styles.ts
@@ -41,6 +41,7 @@ export const ModalOverlay = styled.div`
 `;
 
 export const LoadingContainer = styled.div`
+  grid-column: 1 / 3;
   display: flex;
   width: 100%;
   padding: 2em;


### PR DESCRIPTION
Seems that when calling the twitch API for clips 'start date' is required when using a date range filter. 
Twitch seems to paginate clips by views so I also sorted the UI by views so that it makes more sense

* Normalized dates to midnight
* Sorted clips by views
* Added start date to clip filter